### PR TITLE
leverage npm for bats/bats-assert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-bats/
-rbenv/
 nodenv/
+node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/helpers/assertions"]
-	path = test/helpers/assertions
-	url = https://github.com/jasonkarns/bats-assert

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,1 @@
-install: git clone --depth 1 https://github.com/sstephenson/bats.git && ./test/setup_nodenv
-script: ./bats/bin/bats test
-language: c
+language: node_js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "test/setup_nodenv && bats test"
+    "pretest": "test/setup_nodenv",
+    "test": "bats test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/jasonkarns/nodenv-aliases/issues"
   },
+  "devDependencies": {
+    "bats": "^0.4.2",
+    "bats-assert": "^1.0.1"
+  },
   "keywords": [
     "node",
     "nodenv",

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,4 @@
-load helpers/assertions/all
+load ../node_modules/bats-assert/all
 
 unset NODENV_VERSION
 unset NODENV_DIR


### PR DESCRIPTION
- lets us use npm for bats and bats-assert devdeps, so we don't nee git submodules
- lets us rely on npm-install to get bats, so we don't need custom travis script
- npm-test gives us pretest hook for setup_nodenv
- using node_js travis config makes install and test scripts the default (npm-install, npm-test)